### PR TITLE
getBlockCount check download peer

### DIFF
--- a/src/co/nayuta/lightning/Ptarmigan.java
+++ b/src/co/nayuta/lightning/Ptarmigan.java
@@ -404,6 +404,7 @@ public class Ptarmigan {
         logger.debug("getBlockCount()  count=" + blockHeight);
         if (getPeer() == null) {
             logger.error("  getBlockCount() - peer not found");
+            blockHeight = 0;
         }
         if (blockHash != null) {
             byte[] bhashBytes;


### PR DESCRIPTION
download peerがnullだった場合、getblockcountで0を返す。
ptarmdはgetblockcountが0だった場合、取得失敗と見なすようにする。